### PR TITLE
Cmake dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(${LLVM_DEFINITIONS})
 
 # Standard compile options InstRO uses
 set(instro_default_options -std=c++14 -Werror=return-type)
+include_directories(${CMAKE_BINARY_DIR}/lib/include)
 
 # To select the Compiler backend InstRO wants to use
 # TODO As soon as we port the Rose build to CMake, we need to make this configurable
@@ -18,7 +19,7 @@ set(INSTRO_USE_CLANG True)
 # Whether we can use exceptions
 set(INSTRO_DISABLE_EXCEPTIONS False)
 # Generate the needed lib/include/instro/config.h file
-configure_file(cconfig.h.in ${CMAKE_SOURCE_DIR}/lib/include/instro/config.h)
+configure_file(cconfig.h.in ${CMAKE_BINARY_DIR}/lib/include/instro/config.h)
 
 # Process the subsequent directories
 add_subdirectory(lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,9 @@ find_package(Boost REQUIRED COMPONENTS system iostreams program_options)
 # TODO I think we can move this to the respective targets
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${LLVM_DEFINITIONS})
-#include_directories(${CMAKE_SOURCE_DIR}/lib/include)
 
 # Standard compile options InstRO uses
 set(instro_default_options -std=c++14 -Werror=return-type)
-
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${instro_default_options}")
 
 # To select the Compiler backend InstRO wants to use
 # TODO As soon as we port the Rose build to CMake, we need to make this configurable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,19 +3,27 @@ cmake_minimum_required(VERSION 3.4.3)
 project(InstRO)
 
 find_package(Clang REQUIRED CONFIG)
-
 find_package(Boost REQUIRED COMPONENTS system iostreams program_options)
 
+# TODO I think we can move this to the respective targets
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${LLVM_DEFINITIONS})
+#include_directories(${CMAKE_SOURCE_DIR}/lib/include)
 
+# Standard compile options InstRO uses
 set(instro_default_options -std=c++14 -Werror=return-type)
 
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${instro_default_options}")
 
+# To select the Compiler backend InstRO wants to use
+# TODO As soon as we port the Rose build to CMake, we need to make this configurable
 set(INSTRO_USE_CLANG True)
+# Whether we can use exceptions
 set(INSTRO_DISABLE_EXCEPTIONS False)
+# Generate the needed lib/include/instro/config.h file
 configure_file(cconfig.h.in ${CMAKE_SOURCE_DIR}/lib/include/instro/config.h)
 
+# Process the subsequent directories
 add_subdirectory(lib)
 add_subdirectory(support)
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.4.3)
+
+project(InstRO)
+
+find_package(Clang REQUIRED CONFIG)
+
+find_package(Boost REQUIRED COMPONENTS system iostreams program_options)
+
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${LLVM_DEFINITIONS})
+
+set(instro_default_options -std=c++14 -Werror=return-type)
+
+
+set(INSTRO_USE_CLANG True)
+set(INSTRO_DISABLE_EXCEPTIONS False)
+configure_file(cconfig.h.in ${CMAKE_SOURCE_DIR}/lib/include/instro/config.h)
+
+add_subdirectory(lib)
+add_subdirectory(support)
+add_subdirectory(test)
+add_subdirectory(examples)

--- a/cconfig.h.in
+++ b/cconfig.h.in
@@ -1,0 +1,35 @@
+/*
+ * This file is used by the CMake build system to generate a config,in file.
+ * DO NOT CHANGE THIS FILE!
+ *
+ */
+
+#ifndef INSTRO_CONFIG_H
+#define INSTRO_CONFIG_H
+
+
+#cmakedefine01 INSTRO_DISABLE_EXCEPTIONS @USE_EXCEPTIONS@
+#cmakedefine01 INSTRO_USE_CLANG @NOT_IN_THE_NAME@
+
+
+
+namespace InstRO {
+namespace Config {
+struct BuildInstallConfig {
+	// This is always available (but useless?)
+	const char *const repositoryRelativePath = "@top_srcdir@";
+
+	// This is always available (useless as well?)
+	const char *const buildRelativePath = "@top_builddir@";
+
+	// We probe at configure for the two paths
+	const char *const repositoryRealpath = "@am_aux_dir@";
+	const char *const builddirRealpath = "@am_build_dir@";
+
+	// This one may be empty, as the user does not need to specify it
+	const char *const prefixAbsolutePath = "@CONFIG_INSTALL_DIR@";
+};
+} // Config
+} // InstRO
+
+#endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,9 +1,11 @@
+# Process part-libraries
 add_subdirectory(src/clang)
 add_subdirectory(src/core)
 add_subdirectory(src/pass)
 add_subdirectory(src/tooling)
 add_subdirectory(src/utility)
 
+# The InstRO library
 add_library(InstRO SHARED src/Instrumentor 
 											src/Pass 
 											src/PassFactory)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -13,4 +13,9 @@ add_library(InstRO SHARED src/Instrumentor
 target_include_directories(InstRO PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")
 target_compile_options(InstRO PUBLIC ${instro_default_options})
 
-target_link_libraries(InstRO PUBLIC InstRO_core InstRO_clang InstRO_pass InstRO_util InstRO_tooling ${Boost_LIBRARIES})
+target_link_libraries(InstRO PUBLIC InstRO_core 
+																		InstRO_clang 
+																		InstRO_pass 
+																		InstRO_util 
+																		InstRO_tooling 
+																		${Boost_LIBRARIES})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_subdirectory(src/clang)
+add_subdirectory(src/core)
+add_subdirectory(src/pass)
+add_subdirectory(src/tooling)
+add_subdirectory(src/utility)
+
+add_library(InstRO SHARED src/Instrumentor 
+											src/Pass 
+											src/PassFactory)
+
+target_include_directories(InstRO PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")
+target_compile_options(InstRO PUBLIC ${instro_default_options})
+
+target_link_libraries(InstRO PUBLIC InstRO_core InstRO_clang InstRO_pass InstRO_util InstRO_tooling ${Boost_LIBRARIES})

--- a/lib/include/instro/clang/core/ClangConstruct.h
+++ b/lib/include/instro/clang/core/ClangConstruct.h
@@ -23,6 +23,7 @@ enum class ConstructKind {
 	CK_Stmt = 2,
 };
 
+
 /**
  * @brief A Construct representing AST nodes of the Clang compiler infrastructure.
  * A ClangConstruct represents either a declaration or a statement.
@@ -76,6 +77,7 @@ class ClangConstruct : public InstRO::Core::Construct {
 	static clang::SourceManager& getSourceManager();
 
  private:
+
 	ConstructKind kind;
 	void* construct;
 

--- a/lib/include/instro/clang/core/ClangPassExecuter.h
+++ b/lib/include/instro/clang/core/ClangPassExecuter.h
@@ -76,8 +76,8 @@ InstRO::Clang::VisitingPassExecuter<T>::VisitingPassExecuter(clang::ASTContext *
 template <typename T>
 void InstRO::Clang::VisitingPassExecuter<T>::execute(T *pass) {
 	assert(pass != nullptr);
-	assert(context != nullptr);
-	assert(context->getTranslationUnitDecl() != nullptr && "translation unit null");
+	assert(this->context != nullptr);
+	assert(this->context->getTranslationUnitDecl() != nullptr && "translation unit null");
 	// traverse the Clang AST
 	pass->TraverseDecl(this->context->getTranslationUnitDecl());
 }

--- a/lib/src/clang/CMakeLists.txt
+++ b/lib/src/clang/CMakeLists.txt
@@ -1,0 +1,23 @@
+
+add_library(InstRO_clang SHARED ClangInstrumentor.cpp)
+set(lib_instro_clang_incl "${CMAKE_SOURCE_DIR}/lib/include/instro/clang")
+
+target_include_directories(InstRO_clang PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")
+target_compile_options(InstRO_clang PUBLIC ${instro_default_options})
+
+# Have a short hand.
+set(ccsd ${CMAKE_CURRENT_SOURCE_DIR})
+
+# FIXME split that into the actual groups...
+set(clang_core_files 	${ccsd}/core/ClangConstruct
+											${ccsd}/core/ClangPassFactory
+											${ccsd}/pass/adapter/ClangCygProfileAdapter
+											${ccsd}/pass/adapter/ClangMangledNameOutputAdapter
+											${ccsd}/pass/selector/ClangBlackWhitelistSelector
+											${ccsd}/support/ClangConsumerFactory
+											${ccsd}/support/InstROASTConsumer
+											${ccsd}/tooling/ClangConstructTraitInterface)
+											#											${ccsd}/utility/ClangConfigurationPassRegistry)
+
+target_sources(InstRO_clang PUBLIC ${clang_core_files})
+target_link_libraries(InstRO_clang PRIVATE ${CLANG_EXPORTED_TARGETS})

--- a/lib/src/clang/CMakeLists.txt
+++ b/lib/src/clang/CMakeLists.txt
@@ -1,6 +1,13 @@
 
-add_library(InstRO_clang SHARED ClangInstrumentor.cpp)
-set(lib_instro_clang_incl "${CMAKE_SOURCE_DIR}/lib/include/instro/clang")
+add_subdirectory(core)
+add_subdirectory(pass/adapter)
+add_subdirectory(pass/selector)
+add_subdirectory(support)
+add_subdirectory(tooling)
+#add_subdirectory(utility)
+
+# To build the clang abstraction layer implementation
+add_library(InstRO_clang SHARED ClangInstrumentor)
 
 target_include_directories(InstRO_clang PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")
 target_compile_options(InstRO_clang PUBLIC ${instro_default_options})
@@ -9,15 +16,8 @@ target_compile_options(InstRO_clang PUBLIC ${instro_default_options})
 set(ccsd ${CMAKE_CURRENT_SOURCE_DIR})
 
 # FIXME split that into the actual groups...
-set(clang_core_files 	${ccsd}/core/ClangConstruct
-											${ccsd}/core/ClangPassFactory
-											${ccsd}/pass/adapter/ClangCygProfileAdapter
-											${ccsd}/pass/adapter/ClangMangledNameOutputAdapter
-											${ccsd}/pass/selector/ClangBlackWhitelistSelector
-											${ccsd}/support/ClangConsumerFactory
-											${ccsd}/support/InstROASTConsumer
-											${ccsd}/tooling/ClangConstructTraitInterface)
+										# TODO Include the Rapidjson library
 											#											${ccsd}/utility/ClangConfigurationPassRegistry)
 
 target_sources(InstRO_clang PUBLIC ${clang_core_files})
-target_link_libraries(InstRO_clang PRIVATE ${CLANG_EXPORTED_TARGETS})
+target_link_libraries(InstRO_clang PUBLIC InstRO_clang_core InstRO_clang_adapter InstRO_clang_selector InstRO_clang_support InstRO_clang_tooling ${CLANG_EXPORTED_TARGETS})

--- a/lib/src/clang/CMakeLists.txt
+++ b/lib/src/clang/CMakeLists.txt
@@ -1,9 +1,11 @@
 
+# Process the different part-libraries
 add_subdirectory(core)
 add_subdirectory(pass/adapter)
 add_subdirectory(pass/selector)
 add_subdirectory(support)
 add_subdirectory(tooling)
+# This is part of the todo 
 #add_subdirectory(utility)
 
 # To build the clang abstraction layer implementation
@@ -15,9 +17,13 @@ target_compile_options(InstRO_clang PUBLIC ${instro_default_options})
 # Have a short hand.
 set(ccsd ${CMAKE_CURRENT_SOURCE_DIR})
 
-# FIXME split that into the actual groups...
-										# TODO Include the Rapidjson library
-											#											${ccsd}/utility/ClangConfigurationPassRegistry)
+# TODO Include the Rapidjson library
+# ${ccsd}/utility/ClangConfigurationPassRegistry)
 
 target_sources(InstRO_clang PUBLIC ${clang_core_files})
-target_link_libraries(InstRO_clang PUBLIC InstRO_clang_core InstRO_clang_adapter InstRO_clang_selector InstRO_clang_support InstRO_clang_tooling ${CLANG_EXPORTED_TARGETS})
+target_link_libraries(InstRO_clang PUBLIC InstRO_clang_core 
+																					InstRO_clang_adapter 
+																					InstRO_clang_selector 
+																					InstRO_clang_support 
+																					InstRO_clang_tooling 
+																					${CLANG_EXPORTED_TARGETS})

--- a/lib/src/clang/ClangInstrumentor.cpp
+++ b/lib/src/clang/ClangInstrumentor.cpp
@@ -6,7 +6,10 @@
 #include "instro/utility/exception.h"
 
 InstRO::Clang::ClangInstrumentor::ClangInstrumentor(int argc, const char** argv, llvm::cl::OptionCategory& llvmThing)
-		: argc(argc), argv(argv), cop(argc, argv, llvmThing), tool(cop.getCompilations(), cop.getSourcePathList()) {
+		: argc(argc),
+			argv(argv),
+			cop(argc, argv, llvmThing, llvm::cl::NumOccurrencesFlag::Optional),
+			tool(cop.getCompilations(), cop.getSourcePathList()) {
 	InstRO::setInstrumentorInstance(this);
 }
 

--- a/lib/src/clang/core/CMakeLists.txt
+++ b/lib/src/clang/core/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+add_library(InstRO_clang_core SHARED ClangConstruct
+																			ClangPassFactory)
+																		
+target_compile_options(InstRO_clang_core PUBLIC ${instro_default_options})
+target_include_directories(InstRO_clang_core PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")

--- a/lib/src/clang/core/ClangConstruct.cpp
+++ b/lib/src/clang/core/ClangConstruct.cpp
@@ -17,6 +17,12 @@ using namespace InstRO::Clang::Core;
 
 namespace {
 
+namespace funcs {
+	auto& front(clang::ASTContext::DynTypedNodeList l) {
+		return *(l.begin());
+	}
+}
+
 class PredicateMatcherHandler : public clang::ast_matchers::MatchFinder::MatchCallback {
  public:
 	PredicateMatcherHandler() : matchedOnce(false) {}
@@ -126,7 +132,8 @@ class StmtConstructTraitVisitor : public clang::StmtVisitor<StmtConstructTraitVi
 		// ignore the top level compound statement of a function and switch statement
 		auto parents = context.getParents(*stmt);
 		if (parents.size() == 1) {
-			if (parents.front().get<clang::FunctionDecl>() || parents.front().get<clang::SwitchStmt>()) {
+			if (parents[0].get<clang::FunctionDecl>() || parents[0].get<clang::SwitchStmt>()) {
+			//if (parents.front().get<clang::FunctionDecl>() || parents.front().get<clang::SwitchStmt>()) {
 				generateError(stmt);
 			} else {
 				ct = ConstructTrait(ConstructTraitType::CTScopeStatement);
@@ -180,7 +187,8 @@ class StmtConstructTraitVisitor : public clang::StmtVisitor<StmtConstructTraitVi
 		bool isNotAStatement = false;
 		auto parents = context.getParents(*stmt);
 		if (parents.size() == 1) {
-			if (const clang::Stmt *parent = parents.front().get<clang::Stmt>()) {
+			if (const clang::Stmt *parent = parents[0].get<clang::Stmt>()) {
+			//if (const clang::Stmt *parent = parents.front().get<clang::Stmt>()) {
 				isNotAStatement = llvm::isa<clang::Expr>(*parent);
 				if (!isNotAStatement) {
 					if (llvm::isa<clang::ReturnStmt>(parent)) {
@@ -188,7 +196,8 @@ class StmtConstructTraitVisitor : public clang::StmtVisitor<StmtConstructTraitVi
 						isNotAStatement = true;
 					}
 				}
-			} else if (parents.front().get<clang::Decl>()) {
+			} else if (parents[0].get<clang::Decl>()) {
+			//} else if (parents.front().get<clang::Decl>()) {
 				isNotAStatement = true;
 			}
 		}
@@ -307,7 +316,8 @@ class StmtConstructTraitVisitor : public clang::StmtVisitor<StmtConstructTraitVi
 			return false;
 		}
 
-		auto &parent = parents.front();
+		auto &parent = parents[0];
+		//auto &parent = parents.front();
 		if (const clang::IfStmt *ifStmt = parent.get<clang::IfStmt>()) {
 			return ifStmt->getCond() == expr;
 		} else if (const clang::SwitchStmt *switchStmt = parent.get<clang::SwitchStmt>()) {
@@ -331,7 +341,8 @@ class StmtConstructTraitVisitor : public clang::StmtVisitor<StmtConstructTraitVi
 			return false;
 		}
 
-		if (const clang::ForStmt *forStmt = parents.front().get<clang::ForStmt>()) {
+		if (const clang::ForStmt *forStmt = parents[0].get<clang::ForStmt>()) {
+		//if (const clang::ForStmt *forStmt = parents.front().get<clang::ForStmt>()) {
 			return forStmt->getCond() == stmt || forStmt->getInit() == stmt;
 		}
 

--- a/lib/src/clang/core/ClangConstruct.cpp
+++ b/lib/src/clang/core/ClangConstruct.cpp
@@ -17,12 +17,6 @@ using namespace InstRO::Clang::Core;
 
 namespace {
 
-namespace funcs {
-	auto& front(clang::ASTContext::DynTypedNodeList l) {
-		return *(l.begin());
-	}
-}
-
 class PredicateMatcherHandler : public clang::ast_matchers::MatchFinder::MatchCallback {
  public:
 	PredicateMatcherHandler() : matchedOnce(false) {}
@@ -133,7 +127,6 @@ class StmtConstructTraitVisitor : public clang::StmtVisitor<StmtConstructTraitVi
 		auto parents = context.getParents(*stmt);
 		if (parents.size() == 1) {
 			if (parents[0].get<clang::FunctionDecl>() || parents[0].get<clang::SwitchStmt>()) {
-			//if (parents.front().get<clang::FunctionDecl>() || parents.front().get<clang::SwitchStmt>()) {
 				generateError(stmt);
 			} else {
 				ct = ConstructTrait(ConstructTraitType::CTScopeStatement);
@@ -188,7 +181,6 @@ class StmtConstructTraitVisitor : public clang::StmtVisitor<StmtConstructTraitVi
 		auto parents = context.getParents(*stmt);
 		if (parents.size() == 1) {
 			if (const clang::Stmt *parent = parents[0].get<clang::Stmt>()) {
-			//if (const clang::Stmt *parent = parents.front().get<clang::Stmt>()) {
 				isNotAStatement = llvm::isa<clang::Expr>(*parent);
 				if (!isNotAStatement) {
 					if (llvm::isa<clang::ReturnStmt>(parent)) {
@@ -197,7 +189,6 @@ class StmtConstructTraitVisitor : public clang::StmtVisitor<StmtConstructTraitVi
 					}
 				}
 			} else if (parents[0].get<clang::Decl>()) {
-			//} else if (parents.front().get<clang::Decl>()) {
 				isNotAStatement = true;
 			}
 		}
@@ -317,7 +308,6 @@ class StmtConstructTraitVisitor : public clang::StmtVisitor<StmtConstructTraitVi
 		}
 
 		auto &parent = parents[0];
-		//auto &parent = parents.front();
 		if (const clang::IfStmt *ifStmt = parent.get<clang::IfStmt>()) {
 			return ifStmt->getCond() == expr;
 		} else if (const clang::SwitchStmt *switchStmt = parent.get<clang::SwitchStmt>()) {
@@ -342,7 +332,6 @@ class StmtConstructTraitVisitor : public clang::StmtVisitor<StmtConstructTraitVi
 		}
 
 		if (const clang::ForStmt *forStmt = parents[0].get<clang::ForStmt>()) {
-		//if (const clang::ForStmt *forStmt = parents.front().get<clang::ForStmt>()) {
 			return forStmt->getCond() == stmt || forStmt->getInit() == stmt;
 		}
 

--- a/lib/src/clang/pass/adapter/CMakeLists.txt
+++ b/lib/src/clang/pass/adapter/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+add_library(InstRO_clang_adapter SHARED ClangCygProfileAdapter
+																	ClangMangledNameOutputAdapter)
+
+
+target_compile_options(InstRO_clang_adapter PUBLIC ${instro_default_options})
+target_include_directories(InstRO_clang_adapter PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")

--- a/lib/src/clang/pass/selector/CMakeLists.txt
+++ b/lib/src/clang/pass/selector/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+add_library(InstRO_clang_selector SHARED ClangBlackWhitelistSelector)
+
+
+target_compile_options(InstRO_clang_selector PUBLIC ${instro_default_options})
+target_include_directories(InstRO_clang_selector PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")

--- a/lib/src/clang/support/CMakeLists.txt
+++ b/lib/src/clang/support/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+add_library(InstRO_clang_support SHARED ClangConsumerFactory
+																	InstROASTConsumer)
+
+
+target_compile_options(InstRO_clang_support PUBLIC ${instro_default_options})
+target_include_directories(InstRO_clang_support PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")

--- a/lib/src/clang/tooling/CMakeLists.txt
+++ b/lib/src/clang/tooling/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+add_library(InstRO_clang_tooling  SHARED ClangConstructTraitInterface)
+
+
+target_compile_options(InstRO_clang_tooling PUBLIC ${instro_default_options})
+target_include_directories(InstRO_clang_tooling PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")

--- a/lib/src/core/CMakeLists.txt
+++ b/lib/src/core/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+
+add_library(InstRO_core 	SHARED ConstructSet
+														ConstructTraitType
+														PassImplementation
+														SimplePassManager
+														Singleton)
+
+target_include_directories(InstRO_core PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")
+
+target_compile_options(InstRO_core PUBLIC ${instro_default_options})

--- a/lib/src/core/CMakeLists.txt
+++ b/lib/src/core/CMakeLists.txt
@@ -7,5 +7,4 @@ add_library(InstRO_core 	SHARED ConstructSet
 														Singleton)
 
 target_include_directories(InstRO_core PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")
-
 target_compile_options(InstRO_core PUBLIC ${instro_default_options})

--- a/lib/src/pass/CMakeLists.txt
+++ b/lib/src/pass/CMakeLists.txt
@@ -9,5 +9,5 @@ add_library(InstRO_pass SHARED adapter/ConstructPrinterAdapter
 												selector/IdentifierMatcherSelector
 												selector/ProgramEntrySelector)
 
-											target_compile_options(InstRO_pass PUBLIC ${instro_default_options})
-											target_include_directories(InstRO_pass PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")
+target_compile_options(InstRO_pass PUBLIC ${instro_default_options})
+target_include_directories(InstRO_pass PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")

--- a/lib/src/pass/CMakeLists.txt
+++ b/lib/src/pass/CMakeLists.txt
@@ -1,0 +1,13 @@
+
+
+add_library(InstRO_pass SHARED adapter/ConstructPrinterAdapter
+												adapter/DefaultInstrumentationAdapter
+												selector/BooleanCompoundSelector
+												selector/CallPathSelector
+												selector/ConstructTraitSelector
+												selector/ElevatorSelector
+												selector/IdentifierMatcherSelector
+												selector/ProgramEntrySelector)
+
+target_compile_options(InstRO_pass PUBLIC ${instro_default_options})
+target_include_directories(InstRO_pass PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")

--- a/lib/src/pass/CMakeLists.txt
+++ b/lib/src/pass/CMakeLists.txt
@@ -9,5 +9,5 @@ add_library(InstRO_pass SHARED adapter/ConstructPrinterAdapter
 												selector/IdentifierMatcherSelector
 												selector/ProgramEntrySelector)
 
-target_compile_options(InstRO_pass PUBLIC ${instro_default_options})
-target_include_directories(InstRO_pass PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")
+											target_compile_options(InstRO_pass PUBLIC ${instro_default_options})
+											target_include_directories(InstRO_pass PUBLIC "${CMAKE_SOURCE_DIR}/lib/include")

--- a/lib/src/tooling/CMakeLists.txt
+++ b/lib/src/tooling/CMakeLists.txt
@@ -6,6 +6,6 @@ add_library(InstRO_tooling  SHARED ConstructElevator
 														IdentifierProvider
 														NamedConstructAccess)
 
-target_compile_options(InstRO_tooling PUBLIC ${instro_default_options})
-target_include_directories(InstRO_tooling PUBLIC "${CMAKE_SOURCE_DIR}/lib/include" ${Boost_INCLUDE_DIRS})
+													target_compile_options(InstRO_tooling PUBLIC ${instro_default_options})
+													target_include_directories(InstRO_tooling PUBLIC "${CMAKE_SOURCE_DIR}/lib/include" ${Boost_INCLUDE_DIRS})
 

--- a/lib/src/tooling/CMakeLists.txt
+++ b/lib/src/tooling/CMakeLists.txt
@@ -6,6 +6,6 @@ add_library(InstRO_tooling  SHARED ConstructElevator
 														IdentifierProvider
 														NamedConstructAccess)
 
-													target_compile_options(InstRO_tooling PUBLIC ${instro_default_options})
-													target_include_directories(InstRO_tooling PUBLIC "${CMAKE_SOURCE_DIR}/lib/include" ${Boost_INCLUDE_DIRS})
+target_compile_options(InstRO_tooling PUBLIC ${instro_default_options})
+target_include_directories(InstRO_tooling PUBLIC "${CMAKE_SOURCE_DIR}/lib/include" ${Boost_INCLUDE_DIRS})
 

--- a/lib/src/tooling/CMakeLists.txt
+++ b/lib/src/tooling/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+
+add_library(InstRO_tooling  SHARED ConstructElevator
+														ControlFlowGraph
+														ExtendedCallGraph
+														IdentifierProvider
+														NamedConstructAccess)
+
+target_compile_options(InstRO_tooling PUBLIC ${instro_default_options})
+target_include_directories(InstRO_tooling PUBLIC "${CMAKE_SOURCE_DIR}/lib/include" ${Boost_INCLUDE_DIRS})
+

--- a/lib/src/utility/CMakeLists.txt
+++ b/lib/src/utility/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+
+add_library(InstRO_util SHARED BWLFileReader
+														CommandlineHandling
+														#ConfigurationLoader
+														Environment
+														Logger)
+
+target_include_directories(InstRO_util PUBLIC ${CMAKE_SOURCE_DIR}/lib/include ${Boost_INCLUDE_DIR})
+target_compile_options(InstRO_util PUBLIC ${instro_default_options})
+target_link_libraries(InstRO_util PUBLIC ${Boost_LIBRARIES})
+

--- a/lib/src/utility/CMakeLists.txt
+++ b/lib/src/utility/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(InstRO_util SHARED BWLFileReader
 														Environment
 														Logger)
 
-													target_include_directories(InstRO_util PUBLIC ${CMAKE_SOURCE_DIR}/lib/include ${Boost_INCLUDE_DIR})
+target_include_directories(InstRO_util PUBLIC ${CMAKE_SOURCE_DIR}/lib/include ${Boost_INCLUDE_DIR})
 target_compile_options(InstRO_util PUBLIC ${instro_default_options})
 target_link_libraries(InstRO_util PUBLIC ${Boost_LIBRARIES})
 

--- a/lib/src/utility/CMakeLists.txt
+++ b/lib/src/utility/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(InstRO_util SHARED BWLFileReader
 														Environment
 														Logger)
 
-target_include_directories(InstRO_util PUBLIC ${CMAKE_SOURCE_DIR}/lib/include ${Boost_INCLUDE_DIR})
+													target_include_directories(InstRO_util PUBLIC ${CMAKE_SOURCE_DIR}/lib/include ${Boost_INCLUDE_DIR})
 target_compile_options(InstRO_util PUBLIC ${instro_default_options})
 target_link_libraries(InstRO_util PUBLIC ${Boost_LIBRARIES})
 

--- a/readme.md
+++ b/readme.md
@@ -89,10 +89,12 @@ Support for building the InstRO framework with the Clang compiler infrastructure
 #### Build steps
 At least in our environment the following steps are sufficient. However, as noted building with Clang is work in progress.
 
-```
-mkdir build && cd build
-cmake ../repo
-make
+```bash
+$ mkdir build && cd build
+>> We want to build out-of-tree
+$ cmake ../repo
+>> Generating the Makefiles
+$ make
 ```
 
 ## Using InstRO

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,21 @@ Run `make check` in the top level build directory. For more information please c
 ### Building with Clang
 Support for building the InstRO framework with the Clang compiler infrastructure is currently work in progress.
 
-##Using InstRO
+#### Dependencies
+- CMake >= 3.4.3
+- Clang 3.9
+- Boost 1.60
+
+#### Build steps
+At least in our environment the following steps are sufficient. However, as noted building with Clang is work in progress.
+
+```
+mkdir build && cd build
+cmake ../repo
+make
+```
+
+## Using InstRO
 InstRO includes a few examples which demonstrate some of its components.
 These examples can be found in either `$(builddir)/examples` or, if InstRO has been installed, in `$(installdir)/bin`.
 When installed, invoking an example is as easy as changing into the `bin` directory and invoking an example translator on a source file.

--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ Support for building the InstRO framework with the Clang compiler infrastructure
 
 #### Dependencies
 - CMake >= 3.4.3
-- Clang 3.9
+- Clang 3.9 (enabled exceptions and RTTI)
 - Boost 1.60
 
 #### Build steps

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,13 @@
 
-
+# Build the supporting infrastructure library for the tests
 add_library(InstRO_clang_test lib/TestAdapter.cpp)
+
 target_include_directories(InstRO_clang_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/lib/include)
 target_compile_options(InstRO_clang_test PUBLIC ${instro_default_options})
 
+# Build the test case binary
 add_executable(ConstructHierarchySelectionTest ConstructHierarchySelectionTestMain)
+
 target_include_directories(ConstructHierarchySelectionTest PUBLIC "${CMAKE_SOURCE_DIR}/lib/include" ${CMAKE_CURRENT_SOURCE_DIR} ${Boost_INCLUDE_DIRS})
-target_compile_options(ConstructHierarchySelectionTest PUBLIC -std=c++11 -Werror=return-type)
-#target_compile_definitions(ConstructHierarchySelectionTest PUBLIC INSTRO_USE_CLANG)
-target_link_libraries(ConstructHierarchySelectionTest InstRO_clang_test InstRO InstRO_clang_test ${CLANG_EXPORTED_TARGETS} ${Boost_LIBRARIES})
+target_compile_options(ConstructHierarchySelectionTest PUBLIC ${instro_default_options})
+target_link_libraries(ConstructHierarchySelectionTest InstRO_clang_test InstRO ${CLANG_EXPORTED_TARGETS} ${Boost_LIBRARIES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+
+add_library(InstRO_clang_test lib/TestAdapter.cpp)
+target_include_directories(InstRO_clang_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/lib/include)
+target_compile_options(InstRO_clang_test PUBLIC ${instro_default_options})
+
+add_executable(ConstructHierarchySelectionTest ConstructHierarchySelectionTestMain)
+target_include_directories(ConstructHierarchySelectionTest PUBLIC "${CMAKE_SOURCE_DIR}/lib/include" ${CMAKE_CURRENT_SOURCE_DIR} ${Boost_INCLUDE_DIRS})
+target_compile_options(ConstructHierarchySelectionTest PUBLIC -std=c++11 -Werror=return-type)
+#target_compile_definitions(ConstructHierarchySelectionTest PUBLIC INSTRO_USE_CLANG)
+target_link_libraries(ConstructHierarchySelectionTest InstRO_clang_test InstRO InstRO_clang_test ${CLANG_EXPORTED_TARGETS} ${Boost_LIBRARIES})

--- a/test/ConstructHierarchySelectionTestMain.cpp
+++ b/test/ConstructHierarchySelectionTestMain.cpp
@@ -45,6 +45,7 @@ int main(int argc, char **argv) {
 /*
  * We want to use the same binary for both Rose and Clang
  */
+try {
 #if INSTRO_USE_ROSE
 	using InstrumentorType = RoseTest::RoseTestInstrumentor;
 	InstrumentorType instrumentor(argc, argv);
@@ -85,4 +86,8 @@ int main(int argc, char **argv) {
 
 	// Returns false if everything was fine, true otherwise
 	return instrumentor.testFailed();
+} catch (std::string &s) {
+	std::cout << s << std::endl;
+	return -1;
+}
 }


### PR DESCRIPTION
Added CMakeLists.txt to be able to build the Clang-InstRO part using a recent Clang release.
The clang installation needs to be compiled with RTTI and exceptions enabled.
